### PR TITLE
Configuration script

### DIFF
--- a/bin/cide.conf.example
+++ b/bin/cide.conf.example
@@ -1,5 +1,5 @@
 [DEFAULT]
-server = ./configs/server.conf
-welcomeController = ./configs/welcomeController.conf
-ideController = ./configs/ideController.conf
+server = './configs/server.conf'
+welcomeController = './configs/welcomeController.conf'
+ideController = './configs/ideController.conf'
 

--- a/bin/cide.conf.example
+++ b/bin/cide.conf.example
@@ -1,5 +1,5 @@
 [DEFAULT]
-server = './configs/server.conf'
-welcomeController = './configs/welcomeController.conf'
-ideController = './configs/ideController.conf'
+server = '<<PRJ>>/bin/configs/server.conf'
+welcomeController = '<<PRJ>>/bin/configs/welcomeController.conf'
+ideController = '<<PRJ>>/bin/configs/ideController.conf'
 

--- a/bin/configs/dummy_controller.conf.example
+++ b/bin/configs/dummy_controller.conf.example
@@ -1,7 +1,8 @@
 # DUMMY CONF FILE. MAY BE USED AS COPYPASTA TEMPLATE
 [DEFAULT]
 # -- Variable path and elements to set --
-SRC = "/srv/www/cide.py/src"
+PRJ = "<<PRJ>>"
+SRC = %(PRJ)s + "/src"
 
 # -- Static content config --
 # Set root (/) of static dir/file to src

--- a/bin/configs/ideController.conf.example
+++ b/bin/configs/ideController.conf.example
@@ -1,7 +1,8 @@
 # IDEController app config file
 [DEFAULT]
 # -- Variable path and elements to set --
-SRC = "/srv/www/cide.py/src"
+PRJ = "<<PRJ>>"
+SRC = %(PRJ)s + "/src"
 
 # -- Static content config --
 # Set root (/) of static dir/file to src

--- a/bin/configs/welcomeController.conf.example
+++ b/bin/configs/welcomeController.conf.example
@@ -1,7 +1,8 @@
 # WelcomeController app config file
 [DEFAULT]
 # -- Variable path and elements to set --
-SRC = "/srv/www/cide.py/src"
+PRJ = "<<PRJ>>"
+SRC = %(PRJ)s + "/src"
 
 # -- Static content config --
 # Set root (/) of static dir/file to src

--- a/bin/startCIDE.py
+++ b/bin/startCIDE.py
@@ -1,7 +1,7 @@
 import sys
 import os
-import ConfigParser
 import cherrypy
+from configobj import ConfigObj
 from ws4py.server.cherrypyserver import WebSocketPlugin, WebSocketTool
 from cide.server.welcomeController import WelcomeController
 from cide.server.ideController import IDEController
@@ -16,15 +16,14 @@ else:
 
 
 # Get the server and app config from the config file received
-bin_dir = os.path.dirname(__file__)
+bin_dir = os.path.abspath(os.path.dirname(__file__))
 templates_dir = os.path.join(bin_dir, '../src/templates')
 
-configs = ConfigParser.RawConfigParser()
-configs.read(configs_file)
+configs = ConfigObj(configs_file)
 
-server_conf_file = os.path.join(bin_dir, configs.get('DEFAULT', 'server'))
-welcomeController_conf_file = os.path.join(bin_dir, configs.get('DEFAULT', 'welcomeController'))
-ideController_conf_file = os.path.join(bin_dir, configs.get('DEFAULT', 'ideController'))
+server_conf_file = os.path.join(bin_dir, configs['DEFAULT']['server'])
+welcomeController_conf_file = os.path.join(bin_dir, configs['DEFAULT']['welcomeController'])
+ideController_conf_file = os.path.join(bin_dir, configs['DEFAULT']['ideController'])
 
 # Set server config with config file
 cherrypy.config.update(server_conf_file)

--- a/bin/startCIDE.py
+++ b/bin/startCIDE.py
@@ -8,7 +8,7 @@ from cide.server.ideController import IDEController
 
 # Read config file name from command parameters
 if len(sys.argv) != 2:
-  # XXX Log staring error
+  # XXX Log starting error
   print "Missing or too many arguments. Usage : python startCIDE.py <<configs_file>>"
   sys.exit(1)
 else:
@@ -21,9 +21,9 @@ templates_dir = os.path.join(bin_dir, '../src/templates')
 
 configs = ConfigObj(configs_file)
 
-server_conf_file = os.path.join(bin_dir, configs['DEFAULT']['server'])
-welcomeController_conf_file = os.path.join(bin_dir, configs['DEFAULT']['welcomeController'])
-ideController_conf_file = os.path.join(bin_dir, configs['DEFAULT']['ideController'])
+server_conf_file = configs['DEFAULT']['server']
+welcomeController_conf_file = configs['DEFAULT']['welcomeController']
+ideController_conf_file = configs['DEFAULT']['ideController']
 
 # Set server config with config file
 cherrypy.config.update(server_conf_file)

--- a/python_packages.req
+++ b/python_packages.req
@@ -1,3 +1,4 @@
 CherryPy==3.6.0
 Genshi==0.7
 ws4py==0.3.4
+configobj==5.0.6

--- a/scripts/generate_configs.sh
+++ b/scripts/generate_configs.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+if [ -z "$1" ]
+then
+  echo "Missing project path argument"
+  exit 1
+fi
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+BIN_DIR=$SCRIPT_DIR/../bin
+CONFIGS_DIR=$BIN_DIR/configs
+
+for f in $BIN_DIR/*.conf.example
+do
+  sed -e "s,<<PRJ>>,$1,g" $f > $BIN_DIR/`basename $f .example`
+  if [ -e "$BIN_DIR/`basename $f .example`" ]
+  then
+    echo $BIN_DIR/`basename $f .example` created succesfuly
+  else
+    echo Error creating $BIN_DIR/`basename $f .example`
+  fi
+done
+
+for f in $CONFIGS_DIR/*.conf.example
+do
+  sed -e "s,<<PRJ>>,$1,g" $f > $CONFIGS_DIR/`basename $f .example`
+  if [ -e "$CONFIGS_DIR/`basename $f .example`" ]
+  then
+    echo $CONFIGS_DIR/`basename $f .example` created succesfuly
+  else
+    echo Error creating $CONFIGS_DIR/`basename $f .example`
+  fi
+done
+
+echo Done!
+


### PR DESCRIPTION
@grondinjc @maym2104 Here's the script to copy/fill the config file automatically
Usage : generate_configs.sh /path/to/cide.py   (NOT the src folder, the parent)

I also used ConfigObj for the configs instead of configparser, since it gives a dict-like behaviour (which feels more 'pythonic' and let's me use quotes (') for string in .conf, which keeps the whole thing more unified.
